### PR TITLE
Fix GH Action

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -14,7 +14,7 @@ jobs:
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"
-            - run: npm ci
+            - run: npm install
             - run: npm run build
             - run: npm publish --access public
               env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@topihenrik/funktia",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@topihenrik/funktia",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "dependencies": {
                 "@react-aria/toast": "3.0.0-beta.17",
                 "@react-stately/toast": "3.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@topihenrik/funktia",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "type": "module",
     "files": [
         "dist"


### PR DESCRIPTION
The local setup is on a Windows machine, and GitHub Actions runs on Linux. We need to give GitHub Actions the ability to choose the right package.